### PR TITLE
Add cocktail quiz web app with shareable leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# The-PGR-Cocktail-Quiz
-Cocktail Quiz 
+# The PGR Cocktail Quiz
+
+A browser-based cocktail knowledge quiz that supports a community leaderboard. Each player completes the quiz individually and can then add their results to a ranked list that can be shared with other participants.
+
+## Getting started
+
+1. Open `index.html` in any modern web browser.
+2. Click **Start the Quiz** and answer each multiple-choice question. Feedback appears immediately after every selection.
+3. When you finish, enter your name to publish your score to the leaderboard.
+
+## Leaderboard sharing
+
+* The leaderboard is stored locally in your browser. Use the **Export** button to copy a JSON payload that you can share with other players.
+* Anyone can import shared data to merge results into their local leaderboard using the **Import** button.
+* If your browser blocks local storage, the app will still work, but you will need to export the data before leaving the page to preserve the leaderboard.
+
+## Project structure
+
+* `index.html` – page layout and application markup.
+* `styles.css` – visual styling for the quiz and leaderboard.
+* `script.js` – quiz logic, scoring, and leaderboard management.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>The PGR Cocktail Quiz</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="page-header">
+    <h1>The PGR Cocktail Quiz</h1>
+    <p class="tagline">Test your cocktail knowledge, then compare your score with everyone else.</p>
+  </header>
+
+  <main class="layout">
+    <section id="intro" class="card">
+      <h2>How to Play</h2>
+      <ol class="instructions">
+        <li>Press <strong>Start the Quiz</strong> to begin your individual attempt.</li>
+        <li>Choose the best answer for each question. You will receive instant feedback.</li>
+        <li>When you finish, add your name to the shared leaderboard to see how you rank.</li>
+      </ol>
+      <button id="startButton" class="primary">Start the Quiz</button>
+    </section>
+
+    <section id="quiz" class="card hidden" aria-live="polite">
+      <div class="quiz-header">
+        <h2 id="questionTitle">Question</h2>
+        <span id="questionProgress" class="quiz-progress"></span>
+      </div>
+      <p id="questionText" class="question-text"></p>
+      <div id="options" class="options" role="group" aria-label="Quiz answer choices"></div>
+      <p id="explanation" class="explanation" aria-live="assertive"></p>
+      <div class="quiz-footer">
+        <button id="nextButton" class="primary" disabled>Next Question</button>
+      </div>
+    </section>
+
+    <section id="results" class="card hidden">
+      <h2>Your Results</h2>
+      <p id="resultSummary" class="result-summary"></p>
+      <p id="resultDetails" class="result-details"></p>
+      <form id="scoreForm" class="score-form">
+        <label for="playerName">Add yourself to the leaderboard:</label>
+        <div class="form-row">
+          <input id="playerName" name="playerName" type="text" placeholder="Your name" maxlength="30" autocomplete="name" />
+          <button type="submit" class="primary">Submit Score</button>
+        </div>
+      </form>
+      <p id="scoreSubmittedMessage" class="score-submitted hidden" role="status"></p>
+      <div class="results-actions">
+        <button id="playAgainButton" class="secondary">Play Again</button>
+      </div>
+    </section>
+
+    <section id="leaderboard" class="card">
+      <div class="leaderboard-header">
+        <h2>Community Leaderboard</h2>
+        <p class="leaderboard-description">Every completed quiz can be added to this ranked list. Share the data to compare results with friends or colleagues.</p>
+      </div>
+      <div id="storageWarning" class="storage-warning hidden" role="status"></div>
+      <div class="leaderboard-table-wrapper">
+        <table class="leaderboard-table">
+          <thead>
+            <tr>
+              <th scope="col">Rank</th>
+              <th scope="col">Participant</th>
+              <th scope="col">Score</th>
+              <th scope="col">Time (s)</th>
+              <th scope="col">Completed</th>
+            </tr>
+          </thead>
+          <tbody id="leaderboardBody"></tbody>
+        </table>
+        <p id="emptyLeaderboard" class="empty-leaderboard">No scores yet. Be the first to complete the quiz!</p>
+      </div>
+      <div class="leaderboard-actions">
+        <button id="exportButton" class="secondary">Export leaderboard data</button>
+        <button id="importButton" class="secondary">Import shared data</button>
+        <button id="resetButton" class="link-button">Reset leaderboard</button>
+      </div>
+      <p class="leaderboard-note">Share results by copying the exported data and sending it to other players. They can import it to merge everyone&#39;s scores.</p>
+      <p id="leaderboardStatus" class="leaderboard-status" role="status" aria-live="polite"></p>
+    </section>
+  </main>
+
+  <footer class="page-footer">
+    <p>Built for the PGR Cocktail Quiz challenge.</p>
+  </footer>
+
+  <script src="script.js" defer></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,492 @@
+const quizData = [
+  {
+    question: "Which spirit forms the base of a classic Mojito?",
+    options: ["White rum", "Gin", "Vodka", "Tequila"],
+    correctIndex: 0,
+    explanation: "A Mojito combines white rum with lime, mint, sugar, and soda water."
+  },
+  {
+    question: "What ingredient is responsible for the vivid blue colour in a Blue Lagoon cocktail?",
+    options: ["Blue curaçao", "Blueberry syrup", "Indigo bitters", "Blue food dye"],
+    correctIndex: 0,
+    explanation: "Blue curaçao, an orange-flavoured liqueur, gives the Blue Lagoon its signature hue."
+  },
+  {
+    question: "Which cocktail is famous for being garnished with a celery stalk?",
+    options: ["Bloody Mary", "Irish Coffee", "French 75", "Piña Colada"],
+    correctIndex: 0,
+    explanation: "The savoury Bloody Mary often arrives with a celery garnish and sometimes other snacks."
+  },
+  {
+    question: "When a bartender says to 'build' a cocktail, what should you do?",
+    options: [
+      "Assemble the drink directly in the serving glass",
+      "Shake all ingredients with ice before straining",
+      "Stir the ingredients with ice in a mixing glass",
+      "Blend the ingredients until smooth"
+    ],
+    correctIndex: 0,
+    explanation: "Building a drink means pouring each ingredient straight into the serving glass in order."
+  },
+  {
+    question: "Which of these ingredients is not part of a classic Margarita?",
+    options: ["Sweet vermouth", "Lime juice", "Tequila", "Orange liqueur"],
+    correctIndex: 0,
+    explanation: "A standard Margarita mixes tequila, orange liqueur, and lime juice—no vermouth required."
+  },
+  {
+    question: "The Negroni is traditionally built using which ratio?",
+    options: [
+      "Equal parts gin, Campari, and sweet vermouth",
+      "Two parts gin, one part vermouth, dash of bitters",
+      "Three parts prosecco, two parts Aperol, one part soda",
+      "Equal parts rum, pineapple, and coconut cream"
+    ],
+    correctIndex: 0,
+    explanation: "Negronis are famously balanced with a 1:1:1 ratio of gin, Campari, and sweet vermouth."
+  },
+  {
+    question: "Why do bartenders often use simple syrup instead of granulated sugar in cocktails?",
+    options: [
+      "It dissolves instantly for consistent sweetness",
+      "It is less sweet so it is easier to control",
+      "It makes drinks fizzy",
+      "It preserves fresh juice for longer"
+    ],
+    correctIndex: 0,
+    explanation: "Because simple syrup is already dissolved, it distributes sweetness evenly in cold drinks."
+  },
+  {
+    question: "Which cocktail is traditionally served in a copper mug?",
+    options: ["Moscow Mule", "Mai Tai", "Manhattan", "Cosmopolitan"],
+    correctIndex: 0,
+    explanation: "The copper mug keeps a Moscow Mule frosty and is part of the drink’s identity."
+  },
+  {
+    question: "Expressing a citrus peel over a drink achieves what?",
+    options: [
+      "Releases aromatic oils that perfume the cocktail",
+      "Adds bitterness from the pith",
+      "Introduces extra acidity",
+      "Creates a layer of protective foam"
+    ],
+    correctIndex: 0,
+    explanation: "Expressing the peel spritzes fragrant oils onto the surface and rim of the cocktail."
+  },
+  {
+    question: "Which cocktail is best suited to a stemmed Martini glass?",
+    options: ["A classic gin Martini", "An Old Fashioned", "A Dark ’n’ Stormy", "A Mint Julep"],
+    correctIndex: 0,
+    explanation: "The drink and the glass share a name—the Martini glass showcases the chilled spirit-forward cocktail."
+  }
+];
+
+const leaderboardStorageKey = "pgrCocktailQuizLeaderboard";
+
+const state = {
+  currentQuestion: 0,
+  score: 0,
+  startTime: null,
+  quizActive: false,
+  answerSelected: false,
+  scoreSubmitted: false,
+  leaderboard: []
+};
+
+const elements = {};
+
+function cacheElements() {
+  elements.introSection = document.getElementById("intro");
+  elements.quizSection = document.getElementById("quiz");
+  elements.resultsSection = document.getElementById("results");
+  elements.questionTitle = document.getElementById("questionTitle");
+  elements.questionText = document.getElementById("questionText");
+  elements.options = document.getElementById("options");
+  elements.explanation = document.getElementById("explanation");
+  elements.nextButton = document.getElementById("nextButton");
+  elements.questionProgress = document.getElementById("questionProgress");
+  elements.resultSummary = document.getElementById("resultSummary");
+  elements.resultDetails = document.getElementById("resultDetails");
+  elements.scoreForm = document.getElementById("scoreForm");
+  elements.playerName = document.getElementById("playerName");
+  elements.scoreSubmittedMessage = document.getElementById("scoreSubmittedMessage");
+  elements.playAgainButton = document.getElementById("playAgainButton");
+  elements.leaderboardBody = document.getElementById("leaderboardBody");
+  elements.emptyLeaderboard = document.getElementById("emptyLeaderboard");
+  elements.exportButton = document.getElementById("exportButton");
+  elements.importButton = document.getElementById("importButton");
+  elements.resetButton = document.getElementById("resetButton");
+  elements.leaderboardStatus = document.getElementById("leaderboardStatus");
+  elements.storageWarning = document.getElementById("storageWarning");
+  elements.startButton = document.getElementById("startButton");
+}
+
+function isStorageAvailable() {
+  try {
+    const testKey = "__pgr_test__";
+    window.localStorage.setItem(testKey, "1");
+    window.localStorage.removeItem(testKey);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+const storageAvailable = isStorageAvailable();
+
+function clampNumber(value, min, max, fallback = min) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return fallback;
+  return Math.min(Math.max(number, min), max);
+}
+
+function normaliseEntry(entry) {
+  if (!entry || typeof entry !== "object") {
+    return null;
+  }
+
+  const maxScore = Math.round(clampNumber(entry.maxScore, 1, quizData.length, quizData.length));
+  const score = Math.round(clampNumber(entry.score, 0, maxScore, 0));
+  const durationSeconds = Math.round(clampNumber(entry.durationSeconds, 0, 3600, 0) * 10) / 10;
+  const completedAtRaw = Number(entry.completedAt);
+  const completedAt = Number.isFinite(completedAtRaw) ? completedAtRaw : Date.now();
+  const name =
+    typeof entry.name === "string" && entry.name.trim()
+      ? entry.name.trim().slice(0, 40)
+      : "Anonymous";
+
+  return {
+    name,
+    score,
+    maxScore,
+    durationSeconds,
+    completedAt
+  };
+}
+
+function loadLeaderboard() {
+  if (!storageAvailable) {
+    state.leaderboard = [];
+    elements.storageWarning.classList.remove("hidden");
+    elements.storageWarning.textContent =
+      "Local storage is disabled, so the leaderboard will reset when you refresh the page. Copy the exported data to save it elsewhere.";
+    return;
+  }
+
+  elements.storageWarning.classList.add("hidden");
+  elements.storageWarning.textContent = "";
+
+  const stored = window.localStorage.getItem(leaderboardStorageKey);
+  if (!stored) {
+    state.leaderboard = [];
+    return;
+  }
+
+  try {
+    const parsed = JSON.parse(stored);
+    if (Array.isArray(parsed)) {
+      state.leaderboard = parsed.map(normaliseEntry).filter(Boolean);
+    } else {
+      state.leaderboard = [];
+    }
+  } catch (error) {
+    console.error("Unable to parse leaderboard data", error);
+    state.leaderboard = [];
+  }
+}
+
+function saveLeaderboard() {
+  if (!storageAvailable) {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(leaderboardStorageKey, JSON.stringify(state.leaderboard));
+  } catch (error) {
+    console.error("Unable to save leaderboard", error);
+  }
+}
+
+function formatSeconds(seconds) {
+  return seconds.toLocaleString(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+}
+
+function renderLeaderboard() {
+  elements.leaderboardBody.innerHTML = "";
+
+  if (!state.leaderboard.length) {
+    elements.emptyLeaderboard.classList.remove("hidden");
+    return;
+  }
+
+  elements.emptyLeaderboard.classList.add("hidden");
+
+  const sorted = [...state.leaderboard].sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    if (a.durationSeconds !== b.durationSeconds) return a.durationSeconds - b.durationSeconds;
+    return a.completedAt - b.completedAt;
+  });
+
+  sorted.forEach((entry, index) => {
+    const row = document.createElement("tr");
+    const date = new Date(entry.completedAt);
+    const formattedDate = date.toLocaleString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit"
+    });
+
+    const cells = [
+      (index + 1).toString(),
+      entry.name,
+      `${entry.score} / ${entry.maxScore}`,
+      formatSeconds(entry.durationSeconds),
+      formattedDate
+    ];
+
+    cells.forEach((text) => {
+      const cell = document.createElement("td");
+      cell.textContent = text;
+      row.appendChild(cell);
+    });
+
+    elements.leaderboardBody.appendChild(row);
+  });
+}
+
+function resetQuizState() {
+  state.currentQuestion = 0;
+  state.score = 0;
+  state.startTime = null;
+  state.quizActive = false;
+  state.answerSelected = false;
+  state.scoreSubmitted = false;
+  elements.nextButton.disabled = true;
+  elements.explanation.textContent = "";
+  elements.playerName.value = "";
+  elements.scoreSubmittedMessage.classList.add("hidden");
+  elements.scoreSubmittedMessage.textContent = "";
+  const submitButton = elements.scoreForm.querySelector('button[type="submit"]');
+  if (submitButton) {
+    submitButton.disabled = false;
+  }
+}
+
+function showIntro() {
+  elements.introSection.classList.remove("hidden");
+  elements.quizSection.classList.add("hidden");
+  elements.resultsSection.classList.add("hidden");
+}
+
+function startQuiz() {
+  resetQuizState();
+  state.quizActive = true;
+  state.startTime = Date.now();
+  elements.introSection.classList.add("hidden");
+  elements.resultsSection.classList.add("hidden");
+  elements.quizSection.classList.remove("hidden");
+  renderQuestion();
+}
+
+function renderQuestion() {
+  const question = quizData[state.currentQuestion];
+  elements.questionTitle.textContent = `Question ${state.currentQuestion + 1}`;
+  elements.questionText.textContent = question.question;
+  elements.questionProgress.textContent = `${state.currentQuestion + 1} of ${quizData.length}`;
+  elements.explanation.textContent = "";
+  elements.explanation.style.color = "";
+  elements.nextButton.disabled = true;
+
+  elements.options.innerHTML = "";
+  question.options.forEach((optionText, index) => {
+    const button = document.createElement("button");
+    button.className = "option-button";
+    button.type = "button";
+    button.textContent = optionText;
+    button.dataset.index = index.toString();
+    button.addEventListener("click", () => handleOptionSelect(index));
+    elements.options.appendChild(button);
+  });
+}
+
+function handleOptionSelect(selectedIndex) {
+  if (state.answerSelected) {
+    return;
+  }
+  state.answerSelected = true;
+
+  const question = quizData[state.currentQuestion];
+  const isCorrect = selectedIndex === question.correctIndex;
+
+  const optionButtons = Array.from(elements.options.querySelectorAll("button"));
+  optionButtons.forEach((optionButton, index) => {
+    optionButton.disabled = true;
+    if (index === question.correctIndex) {
+      optionButton.classList.add("correct");
+    }
+    if (index === selectedIndex && !isCorrect) {
+      optionButton.classList.add("incorrect");
+    }
+  });
+
+  if (isCorrect) {
+    state.score += 1;
+    elements.explanation.textContent = `Correct! ${question.explanation}`;
+    elements.explanation.style.color = "var(--success)";
+  } else {
+    elements.explanation.textContent = `Not quite. ${question.explanation}`;
+    elements.explanation.style.color = "var(--danger)";
+  }
+
+  elements.nextButton.disabled = false;
+  elements.nextButton.focus();
+}
+
+function goToNextQuestion() {
+  state.currentQuestion += 1;
+  state.answerSelected = false;
+  if (state.currentQuestion >= quizData.length) {
+    finishQuiz();
+  } else {
+    renderQuestion();
+  }
+}
+
+function finishQuiz() {
+  state.quizActive = false;
+  const endTime = Date.now();
+  const durationSeconds = (endTime - state.startTime) / 1000;
+  const accuracy = Math.round((state.score / quizData.length) * 100);
+
+  elements.quizSection.classList.add("hidden");
+  elements.resultsSection.classList.remove("hidden");
+
+  elements.resultSummary.textContent = `You scored ${state.score} out of ${quizData.length}.`;
+  elements.resultDetails.textContent = `That's ${accuracy}% correct, completed in ${formatSeconds(durationSeconds)} seconds.`;
+
+  elements.scoreSubmittedMessage.classList.add("hidden");
+  elements.scoreSubmittedMessage.textContent = "";
+
+  elements.scoreForm.dataset.duration = durationSeconds.toString();
+  elements.playerName.focus();
+}
+
+function submitScore(event) {
+  event.preventDefault();
+  if (state.scoreSubmitted) {
+    return;
+  }
+
+  const name = elements.playerName.value.trim() || "Anonymous";
+  const durationSeconds = Number(elements.scoreForm.dataset.duration || "0");
+
+  const newEntry = normaliseEntry({
+    name,
+    score: state.score,
+    maxScore: quizData.length,
+    durationSeconds,
+    completedAt: Date.now()
+  });
+
+  if (!newEntry) {
+    setLeaderboardStatus("Something went wrong while saving your score. Please try again.");
+    return;
+  }
+
+  state.leaderboard.push(newEntry);
+  state.scoreSubmitted = true;
+  saveLeaderboard();
+  renderLeaderboard();
+
+  elements.scoreSubmittedMessage.textContent = `${name}, your score has been added to the leaderboard!`;
+  elements.scoreSubmittedMessage.classList.remove("hidden");
+  elements.scoreForm.querySelector('button[type="submit"]').disabled = true;
+}
+
+function exportLeaderboard() {
+  if (!state.leaderboard.length) {
+    setLeaderboardStatus("There are no scores to export yet.");
+    return;
+  }
+
+  const payload = JSON.stringify(state.leaderboard, null, 2);
+
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard
+      .writeText(payload)
+      .then(() => {
+        setLeaderboardStatus("Leaderboard data copied to your clipboard. Share it with other players!");
+      })
+      .catch(() => {
+        setLeaderboardStatus("Copy failed. Please copy the text manually from the prompt.");
+        window.prompt("Copy the leaderboard data:", payload);
+      });
+  } else {
+    setLeaderboardStatus("Clipboard access is unavailable. Copy the data manually from the prompt.");
+    window.prompt("Copy the leaderboard data:", payload);
+  }
+}
+
+function importLeaderboard() {
+  const input = window.prompt("Paste the exported leaderboard data to import it.");
+  if (!input) {
+    setLeaderboardStatus("Import cancelled.");
+    return;
+  }
+
+  try {
+    const parsed = JSON.parse(input);
+    if (!Array.isArray(parsed)) {
+      throw new Error("Data must be an array.");
+    }
+
+    const cleaned = parsed.map(normaliseEntry).filter(Boolean);
+
+    state.leaderboard = [...state.leaderboard, ...cleaned];
+    saveLeaderboard();
+    renderLeaderboard();
+    setLeaderboardStatus("Leaderboard updated with imported scores.");
+  } catch (error) {
+    console.error("Import failed", error);
+    setLeaderboardStatus("Import failed. Please check that you pasted valid JSON data.");
+  }
+}
+
+function resetLeaderboard() {
+  const confirmed = window.confirm("Are you sure you want to clear all leaderboard entries?");
+  if (!confirmed) {
+    return;
+  }
+
+  state.leaderboard = [];
+  saveLeaderboard();
+  renderLeaderboard();
+  setLeaderboardStatus("Leaderboard cleared.");
+}
+
+function setLeaderboardStatus(message) {
+  elements.leaderboardStatus.textContent = message;
+}
+
+function bindEvents() {
+  elements.startButton.addEventListener("click", startQuiz);
+  elements.nextButton.addEventListener("click", goToNextQuestion);
+  elements.scoreForm.addEventListener("submit", submitScore);
+  elements.playAgainButton.addEventListener("click", () => {
+    showIntro();
+  });
+  elements.exportButton.addEventListener("click", exportLeaderboard);
+  elements.importButton.addEventListener("click", importLeaderboard);
+  elements.resetButton.addEventListener("click", resetLeaderboard);
+}
+
+function init() {
+  cacheElements();
+  bindEvents();
+  loadLeaderboard();
+  renderLeaderboard();
+}
+
+document.addEventListener("DOMContentLoaded", init);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,330 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f2f4f8;
+  --card-bg: #ffffffee;
+  --accent: #f97316;
+  --accent-dark: #ea580c;
+  --text: #1f2937;
+  --muted: #4b5563;
+  --border: #e5e7eb;
+  --success: #15803d;
+  --danger: #dc2626;
+  --shadow: 0 18px 36px -18px rgba(15, 23, 42, 0.35);
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Plus Jakarta Sans', 'Segoe UI', Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.page-header,
+.page-footer {
+  text-align: center;
+  padding: 2rem 1rem;
+}
+
+.page-header {
+  background: linear-gradient(135deg, rgba(249, 115, 22, 0.1), rgba(14, 165, 233, 0.1));
+}
+
+.page-header h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(2rem, 1.5rem + 2vw, 3rem);
+  font-weight: 700;
+}
+
+.tagline {
+  margin: 0;
+  color: var(--muted);
+}
+
+.layout {
+  width: min(960px, 95vw);
+  margin: 0 auto;
+  display: grid;
+  gap: 1.5rem;
+  padding: 2rem 0 4rem;
+}
+
+.card {
+  background: var(--card-bg);
+  border-radius: 20px;
+  padding: 2rem;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(6px);
+}
+
+.card h2 {
+  margin-top: 0;
+  font-size: 1.6rem;
+}
+
+.instructions {
+  margin: 1rem 0 2rem;
+  padding-left: 1.25rem;
+  color: var(--muted);
+}
+
+.primary,
+.secondary,
+.link-button {
+  cursor: pointer;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.primary {
+  background: var(--accent);
+  color: white;
+  padding: 0.85rem 1.8rem;
+  box-shadow: 0 12px 20px -12px rgba(249, 115, 22, 0.6);
+}
+
+.primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.primary:not(:disabled):hover,
+.primary:not(:disabled):focus-visible {
+  background: var(--accent-dark);
+  transform: translateY(-1px);
+}
+
+.secondary {
+  background: rgba(14, 165, 233, 0.12);
+  color: #0f172a;
+  padding: 0.75rem 1.6rem;
+  box-shadow: 0 12px 20px -16px rgba(14, 165, 233, 0.6);
+}
+
+.secondary:hover,
+.secondary:focus-visible {
+  transform: translateY(-1px);
+}
+
+.link-button {
+  background: transparent;
+  color: var(--muted);
+  padding: 0.5rem 1rem;
+  text-decoration: underline;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.quiz-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+}
+
+.quiz-progress {
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.question-text {
+  font-size: 1.2rem;
+  margin-bottom: 1.5rem;
+}
+
+.options {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.option-button {
+  width: 100%;
+  text-align: left;
+  padding: 1rem 1.25rem;
+  border-radius: 16px;
+  border: 2px solid transparent;
+  background: rgba(15, 23, 42, 0.04);
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.15s ease;
+}
+
+.option-button:hover,
+.option-button:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(14, 165, 233, 0.35);
+}
+
+.option-button.correct {
+  border-color: rgba(21, 128, 61, 0.6);
+  background: rgba(21, 128, 61, 0.12);
+}
+
+.option-button.incorrect {
+  border-color: rgba(220, 38, 38, 0.6);
+  background: rgba(220, 38, 38, 0.12);
+}
+
+.option-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.85;
+}
+
+.explanation {
+  min-height: 3rem;
+  margin: 1.5rem 0 0;
+  color: var(--muted);
+}
+
+.result-summary {
+  font-size: 1.3rem;
+  font-weight: 600;
+}
+
+.result-details {
+  color: var(--muted);
+}
+
+.score-form {
+  margin: 1.5rem 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.form-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.form-row input {
+  flex: 1 1 220px;
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  font: inherit;
+}
+
+.form-row input:focus-visible {
+  outline: 2px solid rgba(14, 165, 233, 0.4);
+  outline-offset: 2px;
+}
+
+.score-submitted {
+  font-weight: 600;
+  color: var(--success);
+}
+
+.results-actions {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.leaderboard-description {
+  color: var(--muted);
+}
+
+.storage-warning {
+  background: rgba(220, 38, 38, 0.12);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  margin: 1rem 0;
+  color: var(--danger);
+  font-weight: 600;
+}
+
+.leaderboard-table-wrapper {
+  overflow-x: auto;
+}
+
+.leaderboard-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 480px;
+}
+
+.leaderboard-table th,
+.leaderboard-table td {
+  text-align: left;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.leaderboard-table th {
+  color: var(--muted);
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+}
+
+.leaderboard-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 1.5rem 0 0.5rem;
+}
+
+.leaderboard-note {
+  margin: 0.5rem 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.leaderboard-status {
+  min-height: 1.25rem;
+  font-weight: 600;
+}
+
+.empty-leaderboard {
+  color: var(--muted);
+  text-align: center;
+  margin: 1rem 0 0;
+}
+
+@media (max-width: 700px) {
+  .layout {
+    padding: 1.5rem 0 3rem;
+  }
+
+  .card {
+    padding: 1.5rem;
+  }
+
+  .question-text {
+    font-size: 1.1rem;
+  }
+
+  .leaderboard-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .leaderboard-table {
+    min-width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- create an interactive single-page cocktail quiz with instructions, live question flow, and results capture
- implement client-side leaderboard persistence plus export/import utilities for sharing rankings across players
- style the experience with responsive cards and provide updated README guidance for running and sharing the quiz

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c92f1a15e0832a9eedc8c00e7a02e2