### PR TITLE
Add admin editor and cocktail visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
-# The-PGR-Cocktail-Quiz
-Cocktail Quiz 
+# The PGR Cocktail Quiz
+
+A browser-based cocktail knowledge quiz that supports a community leaderboard. Each player completes the quiz individually and can then add their results to a ranked list that can be shared with other participants.
+
+## Getting started
+
+1. Open `index.html` in any modern web browser.
+2. Click **Start the Quiz** and answer each multiple-choice question. Feedback appears immediately after every selection.
+3. When you finish, enter your name to publish your score to the leaderboard.
+
+## Leaderboard sharing
+
+* The leaderboard is stored locally in your browser. Use the **Export** button to copy a JSON payload that you can share with other players.
+* Anyone can import shared data to merge results into their local leaderboard using the **Import** button.
+* If your browser blocks local storage, the app will still work, but you will need to export the data before leaving the page to preserve the leaderboard.
+
+## Customising the question set
+
+* Open `admin.html` and enter the admin password `mixology-master` to unlock the editor.
+* Add, edit, or remove questions and answer options. Each question needs at least two options and one correct answer.
+* Click **Save changes** to write the updated deck to your browser. Refresh `index.html` for players to see the new content.
+* Custom question sets are stored in local storage on the current device. Use your browser's export tools to back up the data if storage is disabled.
+
+## Project structure
+
+* `index.html` – page layout and application markup.
+* `styles.css` – visual styling for the quiz and leaderboard.
+* `script.js` – quiz logic, scoring, and leaderboard management.
+* `data-store.js` – shared helpers for default quiz content and storage.
+* `admin.html` – password-protected editor for managing question content.
+* `admin.js` – admin UI logic for editing and saving question sets.

--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cocktail Quiz Admin</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body class="admin-page">
+  <header class="page-header">
+    <h1>Quiz Content Admin</h1>
+    <p class="tagline">Curate the cocktail trivia served to your players.</p>
+    <div class="cocktail-strip" aria-hidden="true">
+      <div class="cocktail-card">
+        <svg class="cocktail-svg" viewBox="0 0 120 160" role="presentation" focusable="false">
+          <defs>
+            <linearGradient id="admin-martini" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" stop-color="#fde68a" />
+              <stop offset="100%" stop-color="#f97316" />
+            </linearGradient>
+          </defs>
+          <polygon points="24 22 96 22 60 74" fill="url(#admin-martini)" opacity="0.85"></polygon>
+          <polygon points="24 22 96 22 60 74" fill="none" stroke="rgba(255,255,255,0.85)" stroke-width="4"></polygon>
+          <line x1="60" y1="74" x2="60" y2="128" stroke="rgba(255,255,255,0.85)" stroke-width="6" stroke-linecap="round"></line>
+          <ellipse cx="60" cy="140" rx="24" ry="8" fill="rgba(148,163,184,0.45)"></ellipse>
+          <line x1="60" y1="74" x2="102" y2="36" stroke="#fbbf24" stroke-width="4" stroke-linecap="round"></line>
+          <circle cx="98" cy="40" r="7" fill="#22c55e"></circle>
+        </svg>
+      </div>
+      <div class="cocktail-card">
+        <svg class="cocktail-svg" viewBox="0 0 120 160" role="presentation" focusable="false">
+          <defs>
+            <linearGradient id="admin-sunset" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" stop-color="#f472b6" />
+              <stop offset="100%" stop-color="#9333ea" />
+            </linearGradient>
+          </defs>
+          <path
+            d="M48 18 Q36 48 48 80 Q54 98 52 116 Q50 130 44 142 Q42 146 48 146 H82 Q88 146 86 140 Q80 126 78 116 Q76 98 84 80 Q94 48 76 18 Z"
+            fill="url(#admin-sunset)"
+            opacity="0.82"
+          ></path>
+          <path
+            d="M48 18 Q36 48 48 80 Q54 98 52 116 Q50 130 44 142 Q42 146 48 146 H82 Q88 146 86 140 Q80 126 78 116 Q76 98 84 80 Q94 48 76 18 Z"
+            fill="none"
+            stroke="rgba(255,255,255,0.75)"
+            stroke-width="4"
+          ></path>
+          <rect x="76" y="14" width="6" height="70" rx="3" fill="#facc15"></rect>
+          <circle cx="79" cy="18" r="9" fill="#34d399"></circle>
+          <ellipse cx="64" cy="148" rx="26" ry="6" fill="rgba(148,163,184,0.45)"></ellipse>
+        </svg>
+      </div>
+      <div class="cocktail-card">
+        <svg class="cocktail-svg" viewBox="0 0 120 160" role="presentation" focusable="false">
+          <defs>
+            <linearGradient id="admin-rocks" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" stop-color="#38bdf8" />
+              <stop offset="100%" stop-color="#0ea5e9" />
+            </linearGradient>
+          </defs>
+          <rect x="26" y="54" width="68" height="66" rx="12" fill="rgba(255,255,255,0.65)" stroke="rgba(255,255,255,0.8)" stroke-width="4"></rect>
+          <rect x="32" y="62" width="56" height="44" rx="10" fill="url(#admin-rocks)" opacity="0.9"></rect>
+          <rect x="40" y="70" width="18" height="18" rx="4" fill="rgba(255,255,255,0.65)"></rect>
+          <rect x="66" y="76" width="18" height="18" rx="4" fill="rgba(255,255,255,0.4)"></rect>
+          <ellipse cx="60" cy="132" rx="28" ry="6" fill="rgba(148,163,184,0.45)"></ellipse>
+        </svg>
+      </div>
+    </div>
+  </header>
+
+  <main class="layout admin-layout">
+    <section id="loginSection" class="card">
+      <h2>Admin Access</h2>
+      <p>Enter the admin password to edit the question set. Changes apply only to this browser.</p>
+      <p id="storageNotice" class="question-meta"></p>
+      <form id="loginForm" class="login-form">
+        <label for="adminPassword">Password</label>
+        <div class="form-row">
+          <input id="adminPassword" name="adminPassword" type="password" placeholder="Password" autocomplete="current-password" />
+          <button type="submit" class="primary">Unlock editor</button>
+        </div>
+      </form>
+      <p id="loginFeedback" class="form-feedback" role="status" aria-live="polite"></p>
+    </section>
+
+    <section id="editorSection" class="card hidden">
+      <div class="editor-heading">
+        <div>
+          <h2>Question Set Manager</h2>
+          <p id="editorStatus" class="question-meta"></p>
+        </div>
+        <button id="restoreDefaultsButton" class="link-button">Restore default deck</button>
+      </div>
+      <div class="admin-utilities">
+        <button id="addQuestionButton" class="secondary">Add a new question</button>
+        <button id="discardChangesButton" class="link-button">Discard unsaved edits</button>
+      </div>
+      <div id="questionList" class="question-list"></div>
+      <p class="admin-hint">Each question needs at least two answer options. Mark the correct one before saving.</p>
+      <div class="editor-footer">
+        <button id="saveChangesButton" class="primary" disabled>Save changes</button>
+        <p id="saveFeedback" class="save-feedback" role="status" aria-live="polite"></p>
+      </div>
+    </section>
+  </main>
+
+  <footer class="page-footer">
+    <p><a href="index.html">Return to the player quiz</a></p>
+  </footer>
+
+  <script src="data-store.js" defer></script>
+  <script src="admin.js" defer></script>
+</body>
+</html>

--- a/admin.js
+++ b/admin.js
@@ -1,0 +1,546 @@
+"use strict";
+
+const QuizStore = window.PGRQuizStore;
+
+if (!QuizStore) {
+  throw new Error("PGRQuizStore is not defined. Include data-store.js before admin.js.");
+}
+
+const ADMIN_PASSWORD = "mixology-master";
+const MIN_OPTIONS = 2;
+const MAX_OPTIONS = 6;
+
+const state = {
+  storageAvailable: isStorageAvailable(),
+  authenticated: false,
+  questions: [],
+  source: "default",
+  dirty: false,
+  savedSnapshot: "[]"
+};
+
+const elements = {};
+
+function isStorageAvailable() {
+  try {
+    const key = "__pgr_admin_test__";
+    window.localStorage.setItem(key, "1");
+    window.localStorage.removeItem(key);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+function cacheElements() {
+  elements.loginSection = document.getElementById("loginSection");
+  elements.loginForm = document.getElementById("loginForm");
+  elements.passwordInput = document.getElementById("adminPassword");
+  elements.loginFeedback = document.getElementById("loginFeedback");
+  elements.storageNotice = document.getElementById("storageNotice");
+  elements.editorSection = document.getElementById("editorSection");
+  elements.questionList = document.getElementById("questionList");
+  elements.addQuestionButton = document.getElementById("addQuestionButton");
+  elements.discardChangesButton = document.getElementById("discardChangesButton");
+  elements.restoreDefaultsButton = document.getElementById("restoreDefaultsButton");
+  elements.saveChangesButton = document.getElementById("saveChangesButton");
+  elements.editorStatus = document.getElementById("editorStatus");
+  elements.saveFeedback = document.getElementById("saveFeedback");
+}
+
+function bindEvents() {
+  if (elements.loginForm) {
+    elements.loginForm.addEventListener("submit", handleLoginSubmit);
+  }
+  if (elements.addQuestionButton) {
+    elements.addQuestionButton.addEventListener("click", addQuestion);
+  }
+  if (elements.discardChangesButton) {
+    elements.discardChangesButton.addEventListener("click", discardChanges);
+  }
+  if (elements.restoreDefaultsButton) {
+    elements.restoreDefaultsButton.addEventListener("click", restoreDefaultQuestions);
+  }
+  if (elements.saveChangesButton) {
+    elements.saveChangesButton.addEventListener("click", saveChanges);
+  }
+}
+
+function handleLoginSubmit(event) {
+  event.preventDefault();
+  if (state.authenticated) {
+    return;
+  }
+
+  const password = elements.passwordInput.value.trim();
+  if (password !== ADMIN_PASSWORD) {
+    showLoginFeedback("Incorrect password. Please try again.", "error");
+    elements.passwordInput.focus();
+    return;
+  }
+
+  showLoginFeedback("Access granted. Loading questions...", "success");
+  elements.passwordInput.value = "";
+  enterEditor();
+}
+
+function showLoginFeedback(message, variant = "info") {
+  if (!elements.loginFeedback) {
+    return;
+  }
+
+  elements.loginFeedback.textContent = message;
+  elements.loginFeedback.classList.remove("is-error", "is-success");
+  if (variant === "error") {
+    elements.loginFeedback.classList.add("is-error");
+  } else if (variant === "success") {
+    elements.loginFeedback.classList.add("is-success");
+  }
+}
+
+function enterEditor() {
+  state.authenticated = true;
+  if (elements.loginSection) {
+    elements.loginSection.classList.add("hidden");
+  }
+  if (elements.editorSection) {
+    elements.editorSection.classList.remove("hidden");
+  }
+
+  loadQuestionsIntoState();
+  focusFirstQuestion();
+}
+
+function focusFirstQuestion() {
+  window.requestAnimationFrame(() => {
+    const firstQuestion = elements.questionList?.querySelector("textarea");
+    if (firstQuestion) {
+      firstQuestion.focus();
+    }
+  });
+}
+
+function loadQuestionsIntoState() {
+  const result = QuizStore.getQuestions(state.storageAvailable);
+  state.questions = result.questions.map((question) => ({
+    question: question.question,
+    options: [...question.options],
+    correctIndex: Number.isInteger(question.correctIndex)
+      ? Math.min(Math.max(question.correctIndex, 0), Math.max(question.options.length - 1, 0))
+      : 0,
+    explanation: question.explanation || ""
+  }));
+  state.source = result.source;
+  state.savedSnapshot = JSON.stringify(state.questions);
+  state.dirty = false;
+  renderQuestions();
+  updateEditorStatus();
+  updateSaveButton();
+  showFeedback("Questions loaded. Remember to save after making changes.");
+}
+
+function renderQuestions() {
+  if (!elements.questionList) {
+    return;
+  }
+
+  elements.questionList.innerHTML = "";
+
+  if (!state.questions.length) {
+    const emptyMessage = document.createElement("p");
+    emptyMessage.className = "admin-hint";
+    emptyMessage.textContent = "No questions yet. Add one to begin building your quiz.";
+    elements.questionList.appendChild(emptyMessage);
+    return;
+  }
+
+  state.questions.forEach((question, questionIndex) => {
+    const container = document.createElement("article");
+    container.className = "question-editor";
+
+    const header = document.createElement("div");
+    header.className = "question-editor__header";
+
+    const heading = document.createElement("h3");
+    heading.textContent = `Question ${questionIndex + 1}`;
+    header.appendChild(heading);
+
+    const removeQuestionButton = document.createElement("button");
+    removeQuestionButton.type = "button";
+    removeQuestionButton.className = "link-button question-remove";
+    removeQuestionButton.textContent = "Remove question";
+    removeQuestionButton.disabled = state.questions.length <= 1;
+    removeQuestionButton.addEventListener("click", () => removeQuestion(questionIndex));
+    header.appendChild(removeQuestionButton);
+
+    container.appendChild(header);
+
+    const questionLabel = document.createElement("label");
+    questionLabel.className = "field-label";
+    questionLabel.textContent = "Question text";
+
+    const questionInput = document.createElement("textarea");
+    questionInput.className = "question-input";
+    questionInput.rows = 2;
+    questionInput.placeholder = "e.g. Which spirit anchors a Mojito?";
+    questionInput.value = question.question;
+    questionInput.addEventListener("input", (event) => {
+      state.questions[questionIndex].question = event.target.value;
+      markDirty();
+    });
+    questionLabel.appendChild(questionInput);
+    container.appendChild(questionLabel);
+
+    const optionsWrapper = document.createElement("div");
+    optionsWrapper.className = "option-list";
+
+    question.options.forEach((optionText, optionIndex) => {
+      const optionRow = document.createElement("div");
+      optionRow.className = "option-row";
+
+      const optionBadge = document.createElement("span");
+      optionBadge.className = "option-badge";
+      optionBadge.textContent = String.fromCharCode(65 + optionIndex);
+      optionRow.appendChild(optionBadge);
+
+      const optionInput = document.createElement("input");
+      optionInput.type = "text";
+      optionInput.className = "option-input";
+      optionInput.placeholder = "Answer option";
+      optionInput.value = optionText;
+      optionInput.addEventListener("input", (event) => {
+        state.questions[questionIndex].options[optionIndex] = event.target.value;
+        markDirty();
+      });
+      optionRow.appendChild(optionInput);
+
+      const correctLabel = document.createElement("label");
+      correctLabel.className = "option-correct";
+      const correctInput = document.createElement("input");
+      correctInput.type = "radio";
+      correctInput.name = `correct-${questionIndex}`;
+      correctInput.checked = optionIndex === question.correctIndex;
+      correctInput.addEventListener("change", () => {
+        state.questions[questionIndex].correctIndex = optionIndex;
+        markDirty();
+      });
+      correctLabel.appendChild(correctInput);
+      const correctText = document.createElement("span");
+      correctText.textContent = "Correct";
+      correctLabel.appendChild(correctText);
+      optionRow.appendChild(correctLabel);
+
+      const removeOptionButton = document.createElement("button");
+      removeOptionButton.type = "button";
+      removeOptionButton.className = "link-button option-remove";
+      removeOptionButton.textContent = "Remove";
+      removeOptionButton.disabled = question.options.length <= MIN_OPTIONS;
+      removeOptionButton.addEventListener("click", () => removeOption(questionIndex, optionIndex));
+      optionRow.appendChild(removeOptionButton);
+
+      optionsWrapper.appendChild(optionRow);
+    });
+
+    container.appendChild(optionsWrapper);
+
+    const addOptionButton = document.createElement("button");
+    addOptionButton.type = "button";
+    addOptionButton.className = "secondary add-option-button";
+    addOptionButton.textContent = "Add another option";
+    addOptionButton.disabled = question.options.length >= MAX_OPTIONS;
+    addOptionButton.addEventListener("click", () => addOption(questionIndex));
+    container.appendChild(addOptionButton);
+
+    const explanationLabel = document.createElement("label");
+    explanationLabel.className = "field-label";
+    explanationLabel.textContent = "Explanation (optional)";
+    const explanationInput = document.createElement("textarea");
+    explanationInput.className = "explanation-input";
+    explanationInput.rows = 2;
+    explanationInput.placeholder = "Share a short tasting note or reason.";
+    explanationInput.value = question.explanation;
+    explanationInput.addEventListener("input", (event) => {
+      state.questions[questionIndex].explanation = event.target.value;
+      markDirty();
+    });
+    explanationLabel.appendChild(explanationInput);
+    container.appendChild(explanationLabel);
+
+    elements.questionList.appendChild(container);
+  });
+}
+
+function markDirty() {
+  if (!state.dirty) {
+    state.dirty = true;
+    updateSaveButton();
+  }
+  clearFeedback();
+}
+
+function addQuestion() {
+  if (!state.authenticated) {
+    return;
+  }
+
+  state.questions.push({
+    question: "",
+    options: ["", ""],
+    correctIndex: 0,
+    explanation: ""
+  });
+  state.dirty = true;
+  renderQuestions();
+  updateEditorStatus();
+  updateSaveButton();
+  showFeedback("New question added. Fill it out before saving.");
+  focusLastQuestion();
+}
+
+function focusLastQuestion() {
+  window.requestAnimationFrame(() => {
+    const lastQuestion = elements.questionList?.querySelectorAll("textarea");
+    if (lastQuestion && lastQuestion.length) {
+      lastQuestion[lastQuestion.length - 1].focus();
+    }
+  });
+}
+
+function removeQuestion(questionIndex) {
+  if (state.questions.length <= 1) {
+    showFeedback("Keep at least one question in the quiz.", "error");
+    return;
+  }
+
+  const confirmed = window.confirm("Remove this question from the quiz?");
+  if (!confirmed) {
+    return;
+  }
+
+  state.questions.splice(questionIndex, 1);
+  state.dirty = true;
+  renderQuestions();
+  updateEditorStatus();
+  updateSaveButton();
+  showFeedback("Question removed. Remember to save your changes.");
+}
+
+function addOption(questionIndex) {
+  const question = state.questions[questionIndex];
+  if (!question) {
+    return;
+  }
+
+  if (question.options.length >= MAX_OPTIONS) {
+    showFeedback(`Limit reached. Each question can have up to ${MAX_OPTIONS} options.`, "error");
+    return;
+  }
+
+  question.options.push("");
+  state.dirty = true;
+  renderQuestions();
+  updateSaveButton();
+  showFeedback("Another option added.");
+}
+
+function removeOption(questionIndex, optionIndex) {
+  const question = state.questions[questionIndex];
+  if (!question) {
+    return;
+  }
+
+  if (question.options.length <= MIN_OPTIONS) {
+    showFeedback(`Each question needs at least ${MIN_OPTIONS} options.`, "error");
+    return;
+  }
+
+  question.options.splice(optionIndex, 1);
+  if (question.correctIndex === optionIndex) {
+    question.correctIndex = 0;
+  } else if (question.correctIndex > optionIndex) {
+    question.correctIndex -= 1;
+  }
+
+  state.dirty = true;
+  renderQuestions();
+  updateSaveButton();
+  showFeedback("Option removed.");
+}
+
+function discardChanges() {
+  if (!state.dirty) {
+    showFeedback("No unsaved changes to discard.");
+    return;
+  }
+
+  const confirmed = window.confirm("Discard all unsaved edits?");
+  if (!confirmed) {
+    return;
+  }
+
+  state.questions = JSON.parse(state.savedSnapshot);
+  state.dirty = false;
+  renderQuestions();
+  updateEditorStatus();
+  updateSaveButton();
+  showFeedback("Reverted to the last saved version.");
+}
+
+function restoreDefaultQuestions() {
+  const confirmed = window.confirm("Restore the original cocktail question deck? This removes any saved custom questions.");
+  if (!confirmed) {
+    return;
+  }
+
+  const cleared = QuizStore.clearQuestions(state.storageAvailable);
+  state.questions = QuizStore.getDefaultQuestions();
+  state.source = "default";
+  state.savedSnapshot = JSON.stringify(state.questions);
+  state.dirty = false;
+  renderQuestions();
+  updateEditorStatus();
+  updateSaveButton();
+  showFeedback(cleared ? "Default questions restored." : "Defaults loaded for now. Enable storage to keep the change.");
+}
+
+function updateEditorStatus() {
+  if (!elements.editorStatus) {
+    return;
+  }
+
+  const count = state.questions.length;
+  const label = count === 1 ? "question" : "questions";
+  let sourceMessage = "Using the default deck until you save changes.";
+  if (state.source === "custom") {
+    sourceMessage = "A custom deck is currently active on this browser.";
+  }
+  if (!state.storageAvailable) {
+    sourceMessage = "Local storage is blocked, so changes cannot be saved.";
+  }
+
+  elements.editorStatus.textContent = `Editing ${count} ${label}. ${sourceMessage}`;
+}
+
+function updateSaveButton() {
+  if (elements.saveChangesButton) {
+    elements.saveChangesButton.disabled = !state.dirty || !state.storageAvailable;
+  }
+  if (elements.discardChangesButton) {
+    elements.discardChangesButton.disabled = !state.dirty;
+  }
+}
+
+function showFeedback(message, variant = "info") {
+  if (!elements.saveFeedback) {
+    return;
+  }
+
+  elements.saveFeedback.textContent = message;
+  elements.saveFeedback.classList.remove("is-error", "is-success");
+  if (variant === "error") {
+    elements.saveFeedback.classList.add("is-error");
+  } else if (variant === "success") {
+    elements.saveFeedback.classList.add("is-success");
+  }
+}
+
+function clearFeedback() {
+  if (!elements.saveFeedback) {
+    return;
+  }
+
+  elements.saveFeedback.textContent = "";
+  elements.saveFeedback.classList.remove("is-error", "is-success");
+}
+
+function validateQuestions() {
+  if (!state.questions.length) {
+    return { valid: false, message: "Add at least one question before saving." };
+  }
+
+  const cleaned = [];
+  for (let index = 0; index < state.questions.length; index += 1) {
+    const original = state.questions[index];
+    const questionText = original.question.trim();
+    if (!questionText) {
+      return { valid: false, message: `Question ${index + 1} needs text.` };
+    }
+
+    const options = original.options.map((option) => option.trim());
+    if (options.some((option) => !option)) {
+      return { valid: false, message: `Question ${index + 1} has blank answer choices.` };
+    }
+    if (options.length < MIN_OPTIONS) {
+      return { valid: false, message: `Question ${index + 1} needs at least ${MIN_OPTIONS} options.` };
+    }
+
+    let correctIndex = original.correctIndex;
+    if (!Number.isInteger(correctIndex) || correctIndex < 0 || correctIndex >= options.length) {
+      correctIndex = 0;
+    }
+
+    cleaned.push({
+      question: questionText,
+      options,
+      correctIndex,
+      explanation: original.explanation.trim()
+    });
+  }
+
+  return { valid: true, cleaned };
+}
+
+function saveChanges() {
+  if (!state.storageAvailable) {
+    showFeedback("Unable to save because local storage is blocked in this browser.", "error");
+    return;
+  }
+
+  const validation = validateQuestions();
+  if (!validation.valid) {
+    showFeedback(validation.message, "error");
+    return;
+  }
+
+  const result = QuizStore.saveQuestions(validation.cleaned, state.storageAvailable);
+  if (!result.success) {
+    showFeedback("Saving failed. Please try again.", "error");
+    return;
+  }
+
+  state.questions = result.questions.map((question) => ({
+    question: question.question,
+    options: [...question.options],
+    correctIndex: question.correctIndex,
+    explanation: question.explanation
+  }));
+  state.savedSnapshot = JSON.stringify(state.questions);
+  state.source = "custom";
+  state.dirty = false;
+  renderQuestions();
+  updateEditorStatus();
+  updateSaveButton();
+  showFeedback("Custom question set saved. Reload the player quiz to see the updates.", "success");
+}
+
+function updateStorageNotice() {
+  if (!elements.storageNotice) {
+    return;
+  }
+
+  if (state.storageAvailable) {
+    elements.storageNotice.textContent = "Local storage is available. Saved questions stay on this browser.";
+    elements.storageNotice.classList.remove("warning");
+  } else {
+    elements.storageNotice.textContent = "Local storage is blocked, so changes cannot be saved. Enable storage to edit the quiz.";
+    elements.storageNotice.classList.add("warning");
+  }
+}
+
+function initAdmin() {
+  cacheElements();
+  bindEvents();
+  updateStorageNotice();
+}
+
+document.addEventListener("DOMContentLoaded", initAdmin);

--- a/data-store.js
+++ b/data-store.js
@@ -1,0 +1,223 @@
+"use strict";
+
+(function () {
+  const QUESTION_STORAGE_KEY = "pgrCocktailQuizQuestions";
+  const LEADERBOARD_STORAGE_KEY = "pgrCocktailQuizLeaderboard";
+
+  const DEFAULT_QUESTIONS = [
+    {
+      question: "Which spirit forms the base of a classic Mojito?",
+      options: ["White rum", "Gin", "Vodka", "Tequila"],
+      correctIndex: 0,
+      explanation: "A Mojito combines white rum with lime, mint, sugar, and soda water."
+    },
+    {
+      question: "What ingredient is responsible for the vivid blue colour in a Blue Lagoon cocktail?",
+      options: ["Blue curaçao", "Blueberry syrup", "Indigo bitters", "Blue food dye"],
+      correctIndex: 0,
+      explanation: "Blue curaçao, an orange-flavoured liqueur, gives the Blue Lagoon its signature hue."
+    },
+    {
+      question: "Which cocktail is famous for being garnished with a celery stalk?",
+      options: ["Bloody Mary", "Irish Coffee", "French 75", "Piña Colada"],
+      correctIndex: 0,
+      explanation: "The savoury Bloody Mary often arrives with a celery garnish and sometimes other snacks."
+    },
+    {
+      question: "When a bartender says to 'build' a cocktail, what should you do?",
+      options: [
+        "Assemble the drink directly in the serving glass",
+        "Shake all ingredients with ice before straining",
+        "Stir the ingredients with ice in a mixing glass",
+        "Blend the ingredients until smooth"
+      ],
+      correctIndex: 0,
+      explanation: "Building a drink means pouring each ingredient straight into the serving glass in order."
+    },
+    {
+      question: "Which of these ingredients is not part of a classic Margarita?",
+      options: ["Sweet vermouth", "Lime juice", "Tequila", "Orange liqueur"],
+      correctIndex: 0,
+      explanation: "A standard Margarita mixes tequila, orange liqueur, and lime juice—no vermouth required."
+    },
+    {
+      question: "The Negroni is traditionally built using which ratio?",
+      options: [
+        "Equal parts gin, Campari, and sweet vermouth",
+        "Two parts gin, one part vermouth, dash of bitters",
+        "Three parts prosecco, two parts Aperol, one part soda",
+        "Equal parts rum, pineapple, and coconut cream"
+      ],
+      correctIndex: 0,
+      explanation: "Negronis are famously balanced with a 1:1:1 ratio of gin, Campari, and sweet vermouth."
+    },
+    {
+      question: "Why do bartenders often use simple syrup instead of granulated sugar in cocktails?",
+      options: [
+        "It dissolves instantly for consistent sweetness",
+        "It is less sweet so it is easier to control",
+        "It makes drinks fizzy",
+        "It preserves fresh juice for longer"
+      ],
+      correctIndex: 0,
+      explanation: "Because simple syrup is already dissolved, it distributes sweetness evenly in cold drinks."
+    },
+    {
+      question: "Which cocktail is traditionally served in a copper mug?",
+      options: ["Moscow Mule", "Mai Tai", "Manhattan", "Cosmopolitan"],
+      correctIndex: 0,
+      explanation: "The copper mug keeps a Moscow Mule frosty and is part of the drink’s identity."
+    },
+    {
+      question: "Expressing a citrus peel over a drink achieves what?",
+      options: [
+        "Releases aromatic oils that perfume the cocktail",
+        "Adds bitterness from the pith",
+        "Introduces extra acidity",
+        "Creates a layer of protective foam"
+      ],
+      correctIndex: 0,
+      explanation: "Expressing the peel spritzes fragrant oils onto the surface and rim of the cocktail."
+    },
+    {
+      question: "Which cocktail is best suited to a stemmed Martini glass?",
+      options: ["A classic gin Martini", "An Old Fashioned", "A Dark ’n’ Stormy", "A Mint Julep"],
+      correctIndex: 0,
+      explanation: "The drink and the glass share a name—the Martini glass showcases the chilled spirit-forward cocktail."
+    }
+  ];
+
+  function cloneQuestion(question) {
+    return {
+      question: question.question,
+      options: Array.isArray(question.options) ? [...question.options] : [],
+      correctIndex: Number.isInteger(question.correctIndex) ? question.correctIndex : 0,
+      explanation: typeof question.explanation === "string" ? question.explanation : ""
+    };
+  }
+
+  function cloneQuestions(questions) {
+    return questions.map(cloneQuestion);
+  }
+
+  function normaliseQuestion(raw) {
+    if (!raw || typeof raw !== "object") {
+      return null;
+    }
+
+    const questionText = typeof raw.question === "string" ? raw.question.trim() : "";
+    if (!questionText) {
+      return null;
+    }
+
+    const rawOptions = Array.isArray(raw.options) ? raw.options : [];
+    const options = rawOptions
+      .map((option) => (typeof option === "string" ? option.trim() : ""))
+      .filter(Boolean);
+
+    if (options.length < 2) {
+      return null;
+    }
+
+    let correctIndex = Number(raw.correctIndex);
+    if (!Number.isInteger(correctIndex) || correctIndex < 0 || correctIndex >= options.length) {
+      correctIndex = 0;
+    }
+
+    const explanation = typeof raw.explanation === "string" ? raw.explanation.trim() : "";
+
+    return {
+      question: questionText,
+      options,
+      correctIndex,
+      explanation
+    };
+  }
+
+  function getQuestions(storageAvailable) {
+    if (!storageAvailable) {
+      return { questions: cloneQuestions(DEFAULT_QUESTIONS), source: "default", fromStorage: false };
+    }
+
+    let stored;
+    try {
+      stored = window.localStorage.getItem(QUESTION_STORAGE_KEY);
+    } catch (error) {
+      console.warn("Unable to access stored quiz questions", error);
+      return { questions: cloneQuestions(DEFAULT_QUESTIONS), source: "default", fromStorage: false };
+    }
+
+    if (!stored) {
+      return { questions: cloneQuestions(DEFAULT_QUESTIONS), source: "default", fromStorage: false };
+    }
+
+    try {
+      const parsed = JSON.parse(stored);
+      if (!Array.isArray(parsed)) {
+        return { questions: cloneQuestions(DEFAULT_QUESTIONS), source: "default", fromStorage: false };
+      }
+
+      const cleaned = parsed.map(normaliseQuestion).filter(Boolean);
+      if (!cleaned.length) {
+        return { questions: cloneQuestions(DEFAULT_QUESTIONS), source: "default", fromStorage: false };
+      }
+
+      return { questions: cloneQuestions(cleaned), source: "custom", fromStorage: true };
+    } catch (error) {
+      console.error("Failed to parse stored quiz questions", error);
+      return { questions: cloneQuestions(DEFAULT_QUESTIONS), source: "default", fromStorage: false };
+    }
+  }
+
+  function saveQuestions(questions, storageAvailable) {
+    if (!storageAvailable) {
+      return { success: false, error: "storage-unavailable" };
+    }
+
+    const cleaned = [];
+    for (let index = 0; index < questions.length; index += 1) {
+      const normalised = normaliseQuestion(questions[index]);
+      if (!normalised) {
+        return { success: false, error: "validation", index };
+      }
+      cleaned.push(normalised);
+    }
+
+    if (!cleaned.length) {
+      return { success: false, error: "validation", index: 0 };
+    }
+
+    try {
+      window.localStorage.setItem(QUESTION_STORAGE_KEY, JSON.stringify(cleaned));
+    } catch (error) {
+      console.error("Failed to save quiz questions", error);
+      return { success: false, error: "storage-write" };
+    }
+
+    return { success: true, questions: cloneQuestions(cleaned) };
+  }
+
+  function clearQuestions(storageAvailable) {
+    if (!storageAvailable) {
+      return false;
+    }
+
+    try {
+      window.localStorage.removeItem(QUESTION_STORAGE_KEY);
+      return true;
+    } catch (error) {
+      console.error("Failed to clear stored quiz questions", error);
+      return false;
+    }
+  }
+
+  window.PGRQuizStore = {
+    QUESTION_STORAGE_KEY,
+    LEADERBOARD_STORAGE_KEY,
+    getDefaultQuestions: () => cloneQuestions(DEFAULT_QUESTIONS),
+    normaliseQuestion,
+    getQuestions,
+    saveQuestions,
+    clearQuestions
+  };
+})();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>The PGR Cocktail Quiz</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="page-header">
+    <h1>The PGR Cocktail Quiz</h1>
+    <p class="tagline">Test your cocktail knowledge, then compare your score with everyone else.</p>
+    <div class="cocktail-strip" aria-hidden="true">
+      <div class="cocktail-card">
+        <svg class="cocktail-svg" viewBox="0 0 120 160" role="presentation" focusable="false">
+          <defs>
+            <linearGradient id="martini-liquid" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" stop-color="#fde68a" />
+              <stop offset="100%" stop-color="#f97316" />
+            </linearGradient>
+          </defs>
+          <polygon points="24 22 96 22 60 74" fill="url(#martini-liquid)" opacity="0.85"></polygon>
+          <polygon points="24 22 96 22 60 74" fill="none" stroke="rgba(255,255,255,0.85)" stroke-width="4"></polygon>
+          <line x1="60" y1="74" x2="60" y2="128" stroke="rgba(255,255,255,0.85)" stroke-width="6" stroke-linecap="round"></line>
+          <ellipse cx="60" cy="140" rx="24" ry="8" fill="rgba(148,163,184,0.45)"></ellipse>
+          <line x1="60" y1="74" x2="102" y2="36" stroke="#fbbf24" stroke-width="4" stroke-linecap="round"></line>
+          <circle cx="98" cy="40" r="7" fill="#22c55e"></circle>
+        </svg>
+      </div>
+      <div class="cocktail-card">
+        <svg class="cocktail-svg" viewBox="0 0 120 160" role="presentation" focusable="false">
+          <defs>
+            <linearGradient id="sunset-liquid" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" stop-color="#f472b6" />
+              <stop offset="100%" stop-color="#9333ea" />
+            </linearGradient>
+          </defs>
+          <path
+            d="M48 18 Q36 48 48 80 Q54 98 52 116 Q50 130 44 142 Q42 146 48 146 H82 Q88 146 86 140 Q80 126 78 116 Q76 98 84 80 Q94 48 76 18 Z"
+            fill="url(#sunset-liquid)"
+            opacity="0.82"
+          ></path>
+          <path
+            d="M48 18 Q36 48 48 80 Q54 98 52 116 Q50 130 44 142 Q42 146 48 146 H82 Q88 146 86 140 Q80 126 78 116 Q76 98 84 80 Q94 48 76 18 Z"
+            fill="none"
+            stroke="rgba(255,255,255,0.75)"
+            stroke-width="4"
+          ></path>
+          <rect x="76" y="14" width="6" height="70" rx="3" fill="#facc15"></rect>
+          <circle cx="79" cy="18" r="9" fill="#34d399"></circle>
+          <ellipse cx="64" cy="148" rx="26" ry="6" fill="rgba(148,163,184,0.45)"></ellipse>
+        </svg>
+      </div>
+      <div class="cocktail-card">
+        <svg class="cocktail-svg" viewBox="0 0 120 160" role="presentation" focusable="false">
+          <defs>
+            <linearGradient id="rocks-liquid" x1="0%" y1="0%" x2="0%" y2="100%">
+              <stop offset="0%" stop-color="#38bdf8" />
+              <stop offset="100%" stop-color="#0ea5e9" />
+            </linearGradient>
+          </defs>
+          <rect x="26" y="54" width="68" height="66" rx="12" fill="rgba(255,255,255,0.65)" stroke="rgba(255,255,255,0.8)" stroke-width="4"></rect>
+          <rect x="32" y="62" width="56" height="44" rx="10" fill="url(#rocks-liquid)" opacity="0.9"></rect>
+          <rect x="40" y="70" width="18" height="18" rx="4" fill="rgba(255,255,255,0.65)"></rect>
+          <rect x="66" y="76" width="18" height="18" rx="4" fill="rgba(255,255,255,0.4)"></rect>
+          <ellipse cx="60" cy="132" rx="28" ry="6" fill="rgba(148,163,184,0.45)"></ellipse>
+        </svg>
+      </div>
+    </div>
+  </header>
+
+  <main class="layout">
+    <section id="intro" class="card">
+      <h2>How to Play</h2>
+      <ol class="instructions">
+        <li>Press <strong>Start the Quiz</strong> to begin your individual attempt.</li>
+        <li>Choose the best answer for each question. You will receive instant feedback.</li>
+        <li>When you finish, add your name to the shared leaderboard to see how you rank.</li>
+      </ol>
+      <p id="questionCount" class="question-meta">This quiz currently pulls from 10 questions.</p>
+      <p id="questionSource" class="question-meta">Using the default cocktail trivia deck curated by PGR.</p>
+      <button id="startButton" class="primary">Start the Quiz</button>
+    </section>
+
+    <section id="quiz" class="card hidden" aria-live="polite">
+      <div class="quiz-header">
+        <h2 id="questionTitle">Question</h2>
+        <span id="questionProgress" class="quiz-progress"></span>
+      </div>
+      <p id="questionText" class="question-text"></p>
+      <div id="options" class="options" role="group" aria-label="Quiz answer choices"></div>
+      <p id="explanation" class="explanation" aria-live="assertive"></p>
+      <div class="quiz-footer">
+        <button id="nextButton" class="primary" disabled>Next Question</button>
+      </div>
+    </section>
+
+    <section id="results" class="card hidden">
+      <h2>Your Results</h2>
+      <p id="resultSummary" class="result-summary"></p>
+      <p id="resultDetails" class="result-details"></p>
+      <form id="scoreForm" class="score-form">
+        <label for="playerName">Add yourself to the leaderboard:</label>
+        <div class="form-row">
+          <input id="playerName" name="playerName" type="text" placeholder="Your name" maxlength="30" autocomplete="name" />
+          <button type="submit" class="primary">Submit Score</button>
+        </div>
+      </form>
+      <p id="scoreSubmittedMessage" class="score-submitted hidden" role="status"></p>
+      <div class="results-actions">
+        <button id="playAgainButton" class="secondary">Play Again</button>
+      </div>
+    </section>
+
+    <section id="leaderboard" class="card">
+      <div class="leaderboard-header">
+        <h2>Community Leaderboard</h2>
+        <p class="leaderboard-description">Every completed quiz can be added to this ranked list. Share the data to compare results with friends or colleagues.</p>
+      </div>
+      <div id="storageWarning" class="storage-warning hidden" role="status"></div>
+      <div class="leaderboard-table-wrapper">
+        <table class="leaderboard-table">
+          <thead>
+            <tr>
+              <th scope="col">Rank</th>
+              <th scope="col">Participant</th>
+              <th scope="col">Score</th>
+              <th scope="col">Time (s)</th>
+              <th scope="col">Completed</th>
+            </tr>
+          </thead>
+          <tbody id="leaderboardBody"></tbody>
+        </table>
+        <p id="emptyLeaderboard" class="empty-leaderboard">No scores yet. Be the first to complete the quiz!</p>
+      </div>
+      <div class="leaderboard-actions">
+        <button id="exportButton" class="secondary">Export leaderboard data</button>
+        <button id="importButton" class="secondary">Import shared data</button>
+        <button id="resetButton" class="link-button">Reset leaderboard</button>
+      </div>
+      <p class="leaderboard-note">Share results by copying the exported data and sending it to other players. They can import it to merge everyone&#39;s scores.</p>
+      <p id="leaderboardStatus" class="leaderboard-status" role="status" aria-live="polite"></p>
+    </section>
+  </main>
+
+  <footer class="page-footer">
+    <p>
+      Built for the PGR Cocktail Quiz challenge.
+      <span class="admin-entry">Admin? <a href="admin.html">Manage the question set</a>.</span>
+    </p>
+  </footer>
+
+  <script src="data-store.js" defer></script>
+  <script src="script.js" defer></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,502 @@
+"use strict";
+
+const QuizStore = window.PGRQuizStore;
+
+if (!QuizStore) {
+  throw new Error("PGRQuizStore is not defined. Include data-store.js before script.js.");
+}
+
+let quizData = QuizStore.getDefaultQuestions();
+const leaderboardStorageKey = QuizStore.LEADERBOARD_STORAGE_KEY;
+
+const state = {
+  currentQuestion: 0,
+  score: 0,
+  startTime: null,
+  quizActive: false,
+  answerSelected: false,
+  scoreSubmitted: false,
+  leaderboard: [],
+  customQuestionsActive: false
+};
+
+const elements = {};
+
+function cacheElements() {
+  elements.introSection = document.getElementById("intro");
+  elements.quizSection = document.getElementById("quiz");
+  elements.resultsSection = document.getElementById("results");
+  elements.questionTitle = document.getElementById("questionTitle");
+  elements.questionText = document.getElementById("questionText");
+  elements.options = document.getElementById("options");
+  elements.explanation = document.getElementById("explanation");
+  elements.nextButton = document.getElementById("nextButton");
+  elements.questionProgress = document.getElementById("questionProgress");
+  elements.resultSummary = document.getElementById("resultSummary");
+  elements.resultDetails = document.getElementById("resultDetails");
+  elements.scoreForm = document.getElementById("scoreForm");
+  elements.playerName = document.getElementById("playerName");
+  elements.scoreSubmittedMessage = document.getElementById("scoreSubmittedMessage");
+  elements.playAgainButton = document.getElementById("playAgainButton");
+  elements.leaderboardBody = document.getElementById("leaderboardBody");
+  elements.emptyLeaderboard = document.getElementById("emptyLeaderboard");
+  elements.exportButton = document.getElementById("exportButton");
+  elements.importButton = document.getElementById("importButton");
+  elements.resetButton = document.getElementById("resetButton");
+  elements.leaderboardStatus = document.getElementById("leaderboardStatus");
+  elements.storageWarning = document.getElementById("storageWarning");
+  elements.startButton = document.getElementById("startButton");
+  elements.questionCount = document.getElementById("questionCount");
+  elements.questionSource = document.getElementById("questionSource");
+
+  if (elements.startButton && !elements.startButton.dataset.defaultLabel) {
+    elements.startButton.dataset.defaultLabel = elements.startButton.textContent || "Start the Quiz";
+  }
+}
+
+function isStorageAvailable() {
+  try {
+    const testKey = "__pgr_test__";
+    window.localStorage.setItem(testKey, "1");
+    window.localStorage.removeItem(testKey);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+const storageAvailable = isStorageAvailable();
+
+function loadQuizQuestions() {
+  const result = QuizStore.getQuestions(storageAvailable);
+  quizData = result.questions;
+  state.customQuestionsActive = result.source === "custom";
+  updateQuestionMeta();
+  updateStartButtonAvailability();
+}
+
+function updateQuestionMeta() {
+  if (elements.questionCount) {
+    const label = quizData.length === 1 ? "question" : "questions";
+    elements.questionCount.textContent = `This quiz currently pulls from ${quizData.length} ${label}.`;
+  }
+
+  if (elements.questionSource) {
+    if (!storageAvailable) {
+      elements.questionSource.textContent = "Custom question editing is unavailable because local storage is blocked.";
+      elements.questionSource.classList.add("warning");
+    } else if (state.customQuestionsActive) {
+      elements.questionSource.textContent = "Custom cocktail questions are active on this browser.";
+      elements.questionSource.classList.remove("warning");
+    } else {
+      elements.questionSource.textContent = "Using the default cocktail trivia deck curated by PGR.";
+      elements.questionSource.classList.remove("warning");
+    }
+  }
+}
+
+function updateStartButtonAvailability() {
+  if (!elements.startButton) {
+    return;
+  }
+
+  const defaultLabel = elements.startButton.dataset.defaultLabel || "Start the Quiz";
+
+  if (!quizData.length) {
+    elements.startButton.disabled = true;
+    elements.startButton.textContent = "No questions available";
+  } else {
+    elements.startButton.disabled = false;
+    elements.startButton.textContent = defaultLabel;
+  }
+}
+
+function clampNumber(value, min, max, fallback = min) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return fallback;
+  return Math.min(Math.max(number, min), max);
+}
+
+function normaliseEntry(entry) {
+  if (!entry || typeof entry !== "object") {
+    return null;
+  }
+
+  const maxScore = Math.round(clampNumber(entry.maxScore, 1, quizData.length, quizData.length));
+  const score = Math.round(clampNumber(entry.score, 0, maxScore, 0));
+  const durationSeconds = Math.round(clampNumber(entry.durationSeconds, 0, 3600, 0) * 10) / 10;
+  const completedAtRaw = Number(entry.completedAt);
+  const completedAt = Number.isFinite(completedAtRaw) ? completedAtRaw : Date.now();
+  const name =
+    typeof entry.name === "string" && entry.name.trim()
+      ? entry.name.trim().slice(0, 40)
+      : "Anonymous";
+
+  return {
+    name,
+    score,
+    maxScore,
+    durationSeconds,
+    completedAt
+  };
+}
+
+function loadLeaderboard() {
+  if (!storageAvailable) {
+    state.leaderboard = [];
+    elements.storageWarning.classList.remove("hidden");
+    elements.storageWarning.textContent =
+      "Local storage is disabled, so the leaderboard will reset when you refresh the page. Copy the exported data to save it elsewhere. Custom quiz changes can't be saved either.";
+    return;
+  }
+
+  elements.storageWarning.classList.add("hidden");
+  elements.storageWarning.textContent = "";
+
+  const stored = window.localStorage.getItem(leaderboardStorageKey);
+  if (!stored) {
+    state.leaderboard = [];
+    return;
+  }
+
+  try {
+    const parsed = JSON.parse(stored);
+    if (Array.isArray(parsed)) {
+      state.leaderboard = parsed.map(normaliseEntry).filter(Boolean);
+    } else {
+      state.leaderboard = [];
+    }
+  } catch (error) {
+    console.error("Unable to parse leaderboard data", error);
+    state.leaderboard = [];
+  }
+}
+
+function saveLeaderboard() {
+  if (!storageAvailable) {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(leaderboardStorageKey, JSON.stringify(state.leaderboard));
+  } catch (error) {
+    console.error("Unable to save leaderboard", error);
+  }
+}
+
+function formatSeconds(seconds) {
+  return seconds.toLocaleString(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+}
+
+function renderLeaderboard() {
+  elements.leaderboardBody.innerHTML = "";
+
+  if (!state.leaderboard.length) {
+    elements.emptyLeaderboard.classList.remove("hidden");
+    return;
+  }
+
+  elements.emptyLeaderboard.classList.add("hidden");
+
+  const sorted = [...state.leaderboard].sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    if (a.durationSeconds !== b.durationSeconds) return a.durationSeconds - b.durationSeconds;
+    return a.completedAt - b.completedAt;
+  });
+
+  sorted.forEach((entry, index) => {
+    const row = document.createElement("tr");
+    const date = new Date(entry.completedAt);
+    const formattedDate = date.toLocaleString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit"
+    });
+
+    const cells = [
+      (index + 1).toString(),
+      entry.name,
+      `${entry.score} / ${entry.maxScore}`,
+      formatSeconds(entry.durationSeconds),
+      formattedDate
+    ];
+
+    cells.forEach((text) => {
+      const cell = document.createElement("td");
+      cell.textContent = text;
+      row.appendChild(cell);
+    });
+
+    elements.leaderboardBody.appendChild(row);
+  });
+}
+
+function resetQuizState() {
+  state.currentQuestion = 0;
+  state.score = 0;
+  state.startTime = null;
+  state.quizActive = false;
+  state.answerSelected = false;
+  state.scoreSubmitted = false;
+  elements.nextButton.disabled = true;
+  elements.explanation.textContent = "";
+  elements.playerName.value = "";
+  elements.scoreSubmittedMessage.classList.add("hidden");
+  elements.scoreSubmittedMessage.textContent = "";
+  const submitButton = elements.scoreForm.querySelector('button[type="submit"]');
+  if (submitButton) {
+    submitButton.disabled = false;
+  }
+}
+
+function showIntro() {
+  state.quizActive = false;
+  elements.introSection.classList.remove("hidden");
+  elements.quizSection.classList.add("hidden");
+  elements.resultsSection.classList.add("hidden");
+  updateStartButtonAvailability();
+}
+
+function startQuiz() {
+  loadQuizQuestions();
+  if (!quizData.length) {
+    return;
+  }
+
+  resetQuizState();
+  state.quizActive = true;
+  state.startTime = Date.now();
+  elements.introSection.classList.add("hidden");
+  elements.resultsSection.classList.add("hidden");
+  elements.quizSection.classList.remove("hidden");
+  renderQuestion();
+}
+
+function renderQuestion() {
+  const question = quizData[state.currentQuestion];
+  elements.questionTitle.textContent = `Question ${state.currentQuestion + 1}`;
+  elements.questionText.textContent = question.question;
+  elements.questionProgress.textContent = `${state.currentQuestion + 1} of ${quizData.length}`;
+  elements.explanation.textContent = "";
+  elements.explanation.style.color = "";
+  elements.nextButton.disabled = true;
+
+  elements.options.innerHTML = "";
+  question.options.forEach((optionText, index) => {
+    const button = document.createElement("button");
+    button.className = "option-button";
+    button.type = "button";
+    button.textContent = optionText;
+    button.dataset.index = index.toString();
+    button.addEventListener("click", () => handleOptionSelect(index));
+    elements.options.appendChild(button);
+  });
+}
+
+function handleOptionSelect(selectedIndex) {
+  if (state.answerSelected) {
+    return;
+  }
+  state.answerSelected = true;
+
+  const question = quizData[state.currentQuestion];
+  const isCorrect = selectedIndex === question.correctIndex;
+
+  const optionButtons = Array.from(elements.options.querySelectorAll("button"));
+  optionButtons.forEach((optionButton, index) => {
+    optionButton.disabled = true;
+    if (index === question.correctIndex) {
+      optionButton.classList.add("correct");
+    }
+    if (index === selectedIndex && !isCorrect) {
+      optionButton.classList.add("incorrect");
+    }
+  });
+
+  if (isCorrect) {
+    state.score += 1;
+    elements.explanation.textContent = `Correct! ${question.explanation}`;
+    elements.explanation.style.color = "var(--success)";
+  } else {
+    elements.explanation.textContent = `Not quite. ${question.explanation}`;
+    elements.explanation.style.color = "var(--danger)";
+  }
+
+  elements.nextButton.disabled = false;
+  elements.nextButton.focus();
+}
+
+function goToNextQuestion() {
+  state.currentQuestion += 1;
+  state.answerSelected = false;
+  if (state.currentQuestion >= quizData.length) {
+    finishQuiz();
+  } else {
+    renderQuestion();
+  }
+}
+
+function finishQuiz() {
+  state.quizActive = false;
+  const endTime = Date.now();
+  const durationSeconds = (endTime - state.startTime) / 1000;
+  const accuracy = Math.round((state.score / quizData.length) * 100);
+
+  elements.quizSection.classList.add("hidden");
+  elements.resultsSection.classList.remove("hidden");
+
+  elements.resultSummary.textContent = `You scored ${state.score} out of ${quizData.length}.`;
+  elements.resultDetails.textContent = `That's ${accuracy}% correct, completed in ${formatSeconds(durationSeconds)} seconds.`;
+
+  elements.scoreSubmittedMessage.classList.add("hidden");
+  elements.scoreSubmittedMessage.textContent = "";
+
+  elements.scoreForm.dataset.duration = durationSeconds.toString();
+  elements.playerName.focus();
+}
+
+function submitScore(event) {
+  event.preventDefault();
+  if (state.scoreSubmitted) {
+    return;
+  }
+
+  const name = elements.playerName.value.trim() || "Anonymous";
+  const durationSeconds = Number(elements.scoreForm.dataset.duration || "0");
+
+  const newEntry = normaliseEntry({
+    name,
+    score: state.score,
+    maxScore: quizData.length,
+    durationSeconds,
+    completedAt: Date.now()
+  });
+
+  if (!newEntry) {
+    setLeaderboardStatus("Something went wrong while saving your score. Please try again.");
+    return;
+  }
+
+  state.leaderboard.push(newEntry);
+  state.scoreSubmitted = true;
+  saveLeaderboard();
+  renderLeaderboard();
+
+  elements.scoreSubmittedMessage.textContent = `${name}, your score has been added to the leaderboard!`;
+  elements.scoreSubmittedMessage.classList.remove("hidden");
+  elements.scoreForm.querySelector('button[type="submit"]').disabled = true;
+}
+
+function exportLeaderboard() {
+  if (!state.leaderboard.length) {
+    setLeaderboardStatus("There are no scores to export yet.");
+    return;
+  }
+
+  const payload = JSON.stringify(state.leaderboard, null, 2);
+
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard
+      .writeText(payload)
+      .then(() => {
+        setLeaderboardStatus("Leaderboard data copied to your clipboard. Share it with other players!");
+      })
+      .catch(() => {
+        setLeaderboardStatus("Copy failed. Please copy the text manually from the prompt.");
+        window.prompt("Copy the leaderboard data:", payload);
+      });
+  } else {
+    setLeaderboardStatus("Clipboard access is unavailable. Copy the data manually from the prompt.");
+    window.prompt("Copy the leaderboard data:", payload);
+  }
+}
+
+function importLeaderboard() {
+  const input = window.prompt("Paste the exported leaderboard data to import it.");
+  if (!input) {
+    setLeaderboardStatus("Import cancelled.");
+    return;
+  }
+
+  try {
+    const parsed = JSON.parse(input);
+    if (!Array.isArray(parsed)) {
+      throw new Error("Data must be an array.");
+    }
+
+    const cleaned = parsed.map(normaliseEntry).filter(Boolean);
+
+    state.leaderboard = [...state.leaderboard, ...cleaned];
+    saveLeaderboard();
+    renderLeaderboard();
+    setLeaderboardStatus("Leaderboard updated with imported scores.");
+  } catch (error) {
+    console.error("Import failed", error);
+    setLeaderboardStatus("Import failed. Please check that you pasted valid JSON data.");
+  }
+}
+
+function resetLeaderboard() {
+  const confirmed = window.confirm("Are you sure you want to clear all leaderboard entries?");
+  if (!confirmed) {
+    return;
+  }
+
+  state.leaderboard = [];
+  saveLeaderboard();
+  renderLeaderboard();
+  setLeaderboardStatus("Leaderboard cleared.");
+}
+
+function setLeaderboardStatus(message) {
+  elements.leaderboardStatus.textContent = message;
+}
+
+function bindEvents() {
+  if (elements.startButton) {
+    elements.startButton.addEventListener("click", startQuiz);
+  }
+  if (elements.nextButton) {
+    elements.nextButton.addEventListener("click", goToNextQuestion);
+  }
+  if (elements.scoreForm) {
+    elements.scoreForm.addEventListener("submit", submitScore);
+  }
+  if (elements.playAgainButton) {
+    elements.playAgainButton.addEventListener("click", () => {
+      loadQuizQuestions();
+      showIntro();
+    });
+  }
+  if (elements.exportButton) {
+    elements.exportButton.addEventListener("click", exportLeaderboard);
+  }
+  if (elements.importButton) {
+    elements.importButton.addEventListener("click", importLeaderboard);
+  }
+  if (elements.resetButton) {
+    elements.resetButton.addEventListener("click", resetLeaderboard);
+  }
+}
+
+function init() {
+  cacheElements();
+  bindEvents();
+  loadQuizQuestions();
+  loadLeaderboard();
+  renderLeaderboard();
+}
+
+window.addEventListener("storage", (event) => {
+  if (event.key === QuizStore.QUESTION_STORAGE_KEY) {
+    loadQuizQuestions();
+  }
+  if (event.key === leaderboardStorageKey) {
+    loadLeaderboard();
+    renderLeaderboard();
+  }
+});
+
+document.addEventListener("DOMContentLoaded", init);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,587 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f2f4f8;
+  --card-bg: #ffffffee;
+  --accent: #f97316;
+  --accent-dark: #ea580c;
+  --text: #1f2937;
+  --muted: #4b5563;
+  --border: #e5e7eb;
+  --success: #15803d;
+  --danger: #dc2626;
+  --shadow: 0 18px 36px -18px rgba(15, 23, 42, 0.35);
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Plus Jakarta Sans', 'Segoe UI', Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.page-header,
+.page-footer {
+  text-align: center;
+  padding: 2rem 1rem;
+}
+
+.page-header {
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(135deg, rgba(249, 115, 22, 0.1), rgba(14, 165, 233, 0.1));
+}
+
+.page-header h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(2rem, 1.5rem + 2vw, 3rem);
+  font-weight: 700;
+}
+
+.tagline {
+  margin: 0;
+  color: var(--muted);
+}
+
+.cocktail-strip {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  margin: 2rem auto 0;
+  max-width: 640px;
+}
+
+.cocktail-card {
+  width: 120px;
+  height: 160px;
+  border-radius: 24px;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.15));
+  box-shadow: 0 24px 40px -24px rgba(14, 23, 42, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem;
+  backdrop-filter: blur(6px);
+}
+
+.cocktail-svg {
+  width: 100%;
+  height: 100%;
+}
+
+.layout {
+  width: min(960px, 95vw);
+  margin: 0 auto;
+  display: grid;
+  gap: 1.5rem;
+  padding: 2rem 0 4rem;
+}
+
+.admin-layout {
+  width: min(1100px, 95vw);
+}
+
+.card {
+  background: var(--card-bg);
+  border-radius: 20px;
+  padding: 2rem;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(6px);
+}
+
+.card h2 {
+  margin-top: 0;
+  font-size: 1.6rem;
+}
+
+.instructions {
+  margin: 1rem 0 2rem;
+  padding-left: 1.25rem;
+  color: var(--muted);
+}
+
+.question-meta {
+  margin: 0.5rem 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.question-meta.warning {
+  color: var(--danger);
+  font-weight: 600;
+}
+
+.admin-entry {
+  display: inline-block;
+  margin-left: 0.5rem;
+  font-weight: 600;
+}
+
+.admin-entry a {
+  color: var(--accent);
+}
+
+.primary,
+.secondary,
+.link-button {
+  cursor: pointer;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.primary {
+  background: var(--accent);
+  color: white;
+  padding: 0.85rem 1.8rem;
+  box-shadow: 0 12px 20px -12px rgba(249, 115, 22, 0.6);
+}
+
+.primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.primary:not(:disabled):hover,
+.primary:not(:disabled):focus-visible {
+  background: var(--accent-dark);
+  transform: translateY(-1px);
+}
+
+.secondary {
+  background: rgba(14, 165, 233, 0.12);
+  color: #0f172a;
+  padding: 0.75rem 1.6rem;
+  box-shadow: 0 12px 20px -16px rgba(14, 165, 233, 0.6);
+}
+
+.secondary:hover,
+.secondary:focus-visible {
+  transform: translateY(-1px);
+}
+
+.link-button {
+  background: transparent;
+  color: var(--muted);
+  padding: 0.5rem 1rem;
+  text-decoration: underline;
+}
+
+.link-button[disabled] {
+  opacity: 0.45;
+  cursor: not-allowed;
+  text-decoration: none;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.quiz-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+}
+
+.quiz-progress {
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.question-text {
+  font-size: 1.2rem;
+  margin-bottom: 1.5rem;
+}
+
+.options {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.option-button {
+  width: 100%;
+  text-align: left;
+  padding: 1rem 1.25rem;
+  border-radius: 16px;
+  border: 2px solid transparent;
+  background: rgba(15, 23, 42, 0.04);
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.15s ease;
+}
+
+.option-button:hover,
+.option-button:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(14, 165, 233, 0.35);
+}
+
+.option-button.correct {
+  border-color: rgba(21, 128, 61, 0.6);
+  background: rgba(21, 128, 61, 0.12);
+}
+
+.option-button.incorrect {
+  border-color: rgba(220, 38, 38, 0.6);
+  background: rgba(220, 38, 38, 0.12);
+}
+
+.option-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.85;
+}
+
+.explanation {
+  min-height: 3rem;
+  margin: 1.5rem 0 0;
+  color: var(--muted);
+}
+
+.result-summary {
+  font-size: 1.3rem;
+  font-weight: 600;
+}
+
+.result-details {
+  color: var(--muted);
+}
+
+.score-form {
+  margin: 1.5rem 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.form-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.form-row input {
+  flex: 1 1 220px;
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  font: inherit;
+}
+
+.form-row input:focus-visible {
+  outline: 2px solid rgba(14, 165, 233, 0.4);
+  outline-offset: 2px;
+}
+
+textarea {
+  width: 100%;
+  min-height: 96px;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  padding: 0.75rem 1rem;
+  font: inherit;
+  resize: vertical;
+  background: rgba(255, 255, 255, 0.85);
+  color: inherit;
+}
+
+textarea:focus-visible {
+  outline: 2px solid rgba(14, 165, 233, 0.4);
+  outline-offset: 2px;
+}
+
+.score-submitted {
+  font-weight: 600;
+  color: var(--success);
+}
+
+.results-actions {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.form-feedback {
+  margin-top: 1rem;
+  min-height: 1.25rem;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.form-feedback.is-error {
+  color: var(--danger);
+  font-weight: 600;
+}
+
+.form-feedback.is-success {
+  color: var(--success);
+  font-weight: 600;
+}
+
+.admin-hint {
+  color: var(--muted);
+  font-size: 0.9rem;
+  margin: 1.25rem 0 0;
+}
+
+.editor-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.admin-utilities {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 1.5rem 0;
+}
+
+.question-list {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.question-editor {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 16px;
+  padding: 1.5rem;
+  background: rgba(255, 255, 255, 0.6);
+  box-shadow: 0 12px 24px -20px rgba(15, 23, 42, 0.35);
+}
+
+.question-editor__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.question-editor__header h3 {
+  margin: 0;
+}
+
+.question-remove[disabled] {
+  opacity: 0.4;
+  cursor: not-allowed;
+  text-decoration: none;
+}
+
+.field-label {
+  display: grid;
+  gap: 0.5rem;
+  margin: 1.25rem 0 0.75rem;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.field-label:first-of-type {
+  margin-top: 0.5rem;
+}
+
+.question-input,
+.explanation-input {
+  min-height: 84px;
+}
+
+.option-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.option-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.option-badge {
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  background: rgba(14, 165, 233, 0.12);
+  color: #0f172a;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+}
+
+.option-input {
+  flex: 1 1 220px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 0.75rem 1rem;
+  font: inherit;
+  background: rgba(255, 255, 255, 0.85);
+  color: inherit;
+}
+
+.option-input:focus-visible {
+  outline: 2px solid rgba(14, 165, 233, 0.4);
+  outline-offset: 2px;
+}
+
+.option-correct {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.option-correct input {
+  accent-color: var(--accent);
+}
+
+.option-remove[disabled] {
+  opacity: 0.4;
+  cursor: not-allowed;
+  text-decoration: none;
+}
+
+.editor-footer {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.save-feedback {
+  min-height: 1.25rem;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.save-feedback.is-error {
+  color: var(--danger);
+}
+
+.save-feedback.is-success {
+  color: var(--success);
+}
+
+.leaderboard-description {
+  color: var(--muted);
+}
+
+.storage-warning {
+  background: rgba(220, 38, 38, 0.12);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  margin: 1rem 0;
+  color: var(--danger);
+  font-weight: 600;
+}
+
+.leaderboard-table-wrapper {
+  overflow-x: auto;
+}
+
+.leaderboard-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 480px;
+}
+
+.leaderboard-table th,
+.leaderboard-table td {
+  text-align: left;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.leaderboard-table th {
+  color: var(--muted);
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+}
+
+.leaderboard-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 1.5rem 0 0.5rem;
+}
+
+.leaderboard-note {
+  margin: 0.5rem 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.leaderboard-status {
+  min-height: 1.25rem;
+  font-weight: 600;
+}
+
+.empty-leaderboard {
+  color: var(--muted);
+  text-align: center;
+  margin: 1rem 0 0;
+}
+
+@media (max-width: 700px) {
+  .layout {
+    padding: 1.5rem 0 3rem;
+  }
+
+  .card {
+    padding: 1.5rem;
+  }
+
+  .question-text {
+    font-size: 1.1rem;
+  }
+
+  .leaderboard-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .leaderboard-table {
+    min-width: 100%;
+  }
+
+  .cocktail-card {
+    width: 96px;
+    height: 128px;
+  }
+
+  .question-editor {
+    padding: 1.25rem;
+  }
+
+  .editor-heading {
+    align-items: flex-start;
+  }
+
+  .option-input {
+    flex: 1 1 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- introduce a shared data store so the quiz can load default or customised question sets from local storage
- refresh the player experience with cocktail illustrations, question metadata, and messaging about custom content
- add a password-gated admin page for editing questions, including UI styling and storage-aware save flows

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c92f1a15e0832a9eedc8c00e7a02e2